### PR TITLE
feat: add Index field to Task parameters for merging items

### DIFF
--- a/apis/cluster/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/compute/v1alpha1/zz_generated.deepcopy.go
@@ -39158,6 +39158,11 @@ func (in *TaskInitParameters) DeepCopyInto(out *TaskInitParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -43817,6 +43822,11 @@ func (in *TaskObservation) DeepCopyInto(out *TaskObservation) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -44076,6 +44086,11 @@ func (in *TaskParameters) DeepCopyInto(out *TaskParameters) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
 	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey

--- a/apis/cluster/compute/v1alpha1/zz_job_types.go
+++ b/apis/cluster/compute/v1alpha1/zz_job_types.go
@@ -1841,8 +1841,6 @@ type JobInitParameters struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications []EmailNotificationsInitParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentInitParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -1857,8 +1855,6 @@ type JobInitParameters struct {
 	Health []HealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterInitParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -1930,7 +1926,7 @@ type JobInitParameters struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskInitParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3003,8 +2999,6 @@ type JobObservation struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications []EmailNotificationsObservation `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentObservation `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3022,8 +3016,6 @@ type JobObservation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterObservation `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3095,7 +3087,7 @@ type JobObservation struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskObservation `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3152,8 +3144,6 @@ type JobParameters struct {
 	EmailNotifications []EmailNotificationsParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3173,8 +3163,6 @@ type JobParameters struct {
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3269,7 +3257,7 @@ type JobParameters struct {
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +kubebuilder:validation:Optional
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -8730,8 +8718,6 @@ type TaskInitParameters struct {
 	DbtTask []TaskDbtTaskInitParameters `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnInitParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -8769,6 +8755,10 @@ type TaskInitParameters struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health []JobTaskHealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10293,8 +10283,6 @@ type TaskObservation struct {
 	DbtTask []TaskDbtTaskObservation `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnObservation `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10322,6 +10310,10 @@ type TaskObservation struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health []JobTaskHealthObservation `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10416,8 +10408,6 @@ type TaskParameters struct {
 
 	// block specifying dependency(-ies) for a given task.
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10464,6 +10454,11 @@ type TaskParameters struct {
 	// An optional block that specifies the health conditions for the job documented below.
 	// +kubebuilder:validation:Optional
 	Health []JobTaskHealthParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=default
+	Index *string `json:"index" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	// +kubebuilder:validation:Optional

--- a/apis/cluster/compute/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/compute/v1beta1/zz_generated.deepcopy.go
@@ -37624,6 +37624,11 @@ func (in *TaskInitParameters) DeepCopyInto(out *TaskInitParameters) {
 		*out = new(JobTaskHealthInitParameters)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -42045,6 +42050,11 @@ func (in *TaskObservation) DeepCopyInto(out *TaskObservation) {
 		*out = new(JobTaskHealthObservation)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -42258,6 +42268,11 @@ func (in *TaskParameters) DeepCopyInto(out *TaskParameters) {
 		in, out := &in.Health, &out.Health
 		*out = new(JobTaskHealthParameters)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
 	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey

--- a/apis/cluster/compute/v1beta1/zz_job_types.go
+++ b/apis/cluster/compute/v1beta1/zz_job_types.go
@@ -1841,8 +1841,6 @@ type JobInitParameters struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications *EmailNotificationsInitParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentInitParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -1857,8 +1855,6 @@ type JobInitParameters struct {
 	Health *HealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterInitParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -1930,7 +1926,7 @@ type JobInitParameters struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskInitParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3003,8 +2999,6 @@ type JobObservation struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications *EmailNotificationsObservation `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentObservation `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3022,8 +3016,6 @@ type JobObservation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterObservation `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3095,7 +3087,7 @@ type JobObservation struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskObservation `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3152,8 +3144,6 @@ type JobParameters struct {
 	EmailNotifications *EmailNotificationsParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3173,8 +3163,6 @@ type JobParameters struct {
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3269,7 +3257,7 @@ type JobParameters struct {
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +kubebuilder:validation:Optional
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -8730,8 +8718,6 @@ type TaskInitParameters struct {
 	DbtTask *TaskDbtTaskInitParameters `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnInitParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -8769,6 +8755,10 @@ type TaskInitParameters struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health *JobTaskHealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10293,8 +10283,6 @@ type TaskObservation struct {
 	DbtTask *TaskDbtTaskObservation `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnObservation `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10322,6 +10310,10 @@ type TaskObservation struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health *JobTaskHealthObservation `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10416,8 +10408,6 @@ type TaskParameters struct {
 
 	// block specifying dependency(-ies) for a given task.
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10464,6 +10454,11 @@ type TaskParameters struct {
 	// An optional block that specifies the health conditions for the job documented below.
 	// +kubebuilder:validation:Optional
 	Health *JobTaskHealthParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=default
+	Index *string `json:"index" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/compute/v1alpha1/zz_generated.deepcopy.go
@@ -39158,6 +39158,11 @@ func (in *TaskInitParameters) DeepCopyInto(out *TaskInitParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -43817,6 +43822,11 @@ func (in *TaskObservation) DeepCopyInto(out *TaskObservation) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -44076,6 +44086,11 @@ func (in *TaskParameters) DeepCopyInto(out *TaskParameters) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
 	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey

--- a/apis/namespaced/compute/v1alpha1/zz_job_types.go
+++ b/apis/namespaced/compute/v1alpha1/zz_job_types.go
@@ -1842,8 +1842,6 @@ type JobInitParameters struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications []EmailNotificationsInitParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentInitParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -1858,8 +1856,6 @@ type JobInitParameters struct {
 	Health []HealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterInitParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -1931,7 +1927,7 @@ type JobInitParameters struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskInitParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3004,8 +3000,6 @@ type JobObservation struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications []EmailNotificationsObservation `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentObservation `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3023,8 +3017,6 @@ type JobObservation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterObservation `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3096,7 +3088,7 @@ type JobObservation struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskObservation `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3153,8 +3145,6 @@ type JobParameters struct {
 	EmailNotifications []EmailNotificationsParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3174,8 +3164,6 @@ type JobParameters struct {
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3270,7 +3258,7 @@ type JobParameters struct {
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +kubebuilder:validation:Optional
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -8731,8 +8719,6 @@ type TaskInitParameters struct {
 	DbtTask []TaskDbtTaskInitParameters `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnInitParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -8770,6 +8756,10 @@ type TaskInitParameters struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health []JobTaskHealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10294,8 +10284,6 @@ type TaskObservation struct {
 	DbtTask []TaskDbtTaskObservation `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnObservation `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10323,6 +10311,10 @@ type TaskObservation struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health []JobTaskHealthObservation `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10417,8 +10409,6 @@ type TaskParameters struct {
 
 	// block specifying dependency(-ies) for a given task.
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10465,6 +10455,11 @@ type TaskParameters struct {
 	// An optional block that specifies the health conditions for the job documented below.
 	// +kubebuilder:validation:Optional
 	Health []JobTaskHealthParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=default
+	Index *string `json:"index" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/compute/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/compute/v1beta1/zz_generated.deepcopy.go
@@ -37624,6 +37624,11 @@ func (in *TaskInitParameters) DeepCopyInto(out *TaskInitParameters) {
 		*out = new(JobTaskHealthInitParameters)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -42045,6 +42050,11 @@ func (in *TaskObservation) DeepCopyInto(out *TaskObservation) {
 		*out = new(JobTaskHealthObservation)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
+	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey
 		*out = new(string)
@@ -42258,6 +42268,11 @@ func (in *TaskParameters) DeepCopyInto(out *TaskParameters) {
 		in, out := &in.Health, &out.Health
 		*out = new(JobTaskHealthParameters)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Index != nil {
+		in, out := &in.Index, &out.Index
+		*out = new(string)
+		**out = **in
 	}
 	if in.JobClusterKey != nil {
 		in, out := &in.JobClusterKey, &out.JobClusterKey

--- a/apis/namespaced/compute/v1beta1/zz_job_types.go
+++ b/apis/namespaced/compute/v1beta1/zz_job_types.go
@@ -1842,8 +1842,6 @@ type JobInitParameters struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications *EmailNotificationsInitParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentInitParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -1858,8 +1856,6 @@ type JobInitParameters struct {
 	Health *HealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterInitParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -1931,7 +1927,7 @@ type JobInitParameters struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskInitParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3004,8 +3000,6 @@ type JobObservation struct {
 	// (List) An optional set of email addresses notified when runs of this job begins, completes or fails. The default behavior is to not send any emails. This field is a block and is documented below.
 	EmailNotifications *EmailNotificationsObservation `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentObservation `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3023,8 +3017,6 @@ type JobObservation struct {
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterObservation `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3096,7 +3088,7 @@ type JobObservation struct {
 
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskObservation `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -3153,8 +3145,6 @@ type JobParameters struct {
 	EmailNotifications *EmailNotificationsParameters `json:"emailNotifications,omitempty" tf:"email_notifications,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=environmentKey
 	Environment []EnvironmentParameters `json:"environment,omitempty" tf:"environment,omitempty"`
 
 	// Identifier of the interactive cluster to run job on.  Note: running tasks on interactive clusters may lead to increased costs!
@@ -3174,8 +3164,6 @@ type JobParameters struct {
 
 	// A list of job databricks_cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings. Multi-task syntax
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=jobClusterKey
 	JobCluster []JobClusterParameters `json:"jobCluster,omitempty" tf:"job_cluster,omitempty"`
 
 	// (List) An optional list of libraries to be installed on the cluster that will execute the job. See library Configuration Block below.
@@ -3270,7 +3258,7 @@ type JobParameters struct {
 	// A list of task specification that the job will execute. See task Configuration Block below.
 	// +kubebuilder:validation:Optional
 	// +listType=map
-	// +listMapKey=taskKey
+	// +listMapKey=index
 	Task []TaskParameters `json:"task,omitempty" tf:"task,omitempty"`
 
 	// (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -8731,8 +8719,6 @@ type TaskInitParameters struct {
 	DbtTask *TaskDbtTaskInitParameters `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnInitParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -8770,6 +8756,10 @@ type TaskInitParameters struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health *JobTaskHealthInitParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10294,8 +10284,6 @@ type TaskObservation struct {
 	DbtTask *TaskDbtTaskObservation `json:"dbtTask,omitempty" tf:"dbt_task,omitempty"`
 
 	// block specifying dependency(-ies) for a given task.
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnObservation `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10323,6 +10311,10 @@ type TaskObservation struct {
 
 	// An optional block that specifies the health conditions for the job documented below.
 	Health *JobTaskHealthObservation `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:default:=default
+	Index *string `json:"index,omitempty" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	JobClusterKey *string `json:"jobClusterKey,omitempty" tf:"job_cluster_key,omitempty"`
@@ -10417,8 +10409,6 @@ type TaskParameters struct {
 
 	// block specifying dependency(-ies) for a given task.
 	// +kubebuilder:validation:Optional
-	// +listType=map
-	// +listMapKey=taskKey
 	DependsOn []DependsOnParameters `json:"dependsOn,omitempty" tf:"depends_on,omitempty"`
 
 	// An optional description for the job. The maximum length is 1024 characters in UTF-8 encoding.
@@ -10465,6 +10455,11 @@ type TaskParameters struct {
 	// An optional block that specifies the health conditions for the job documented below.
 	// +kubebuilder:validation:Optional
 	Health *JobTaskHealthParameters `json:"health,omitempty" tf:"health,omitempty"`
+
+	// This is an injected field with a default value for being able to merge items of the parent object list.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=default
+	Index *string `json:"index" tf:"-"`
 
 	// Identifier of the Job cluster specified in the job_cluster block.
 	// +kubebuilder:validation:Optional

--- a/config/cluster/job/config.go
+++ b/config/cluster/job/config.go
@@ -74,37 +74,13 @@ func Configure(p *config.Provider) {
 
 		r.ServerSideApplyMergeStrategies["task"] = config.MergeStrategy{
 			ListMergeStrategy: config.ListMergeStrategy{
-				MergeStrategy: config.ListTypeMap,
 				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"taskKey"},
+					InjectedKey: config.InjectedKey{
+						Key:          "index",
+						DefaultValue: "default",
+					},
 				},
-			},
-		}
-
-		r.ServerSideApplyMergeStrategies["environment"] = config.MergeStrategy{
-			ListMergeStrategy: config.ListMergeStrategy{
 				MergeStrategy: config.ListTypeMap,
-				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"environmentKey"},
-				},
-			},
-		}
-
-		r.ServerSideApplyMergeStrategies["job_cluster"] = config.MergeStrategy{
-			ListMergeStrategy: config.ListMergeStrategy{
-				MergeStrategy: config.ListTypeMap,
-				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"jobClusterKey"},
-				},
-			},
-		}
-
-		r.ServerSideApplyMergeStrategies["task.depends_on"] = config.MergeStrategy{
-			ListMergeStrategy: config.ListMergeStrategy{
-				MergeStrategy: config.ListTypeMap,
-				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"taskKey"},
-				},
 			},
 		}
 	})

--- a/config/namespaced/job/config.go
+++ b/config/namespaced/job/config.go
@@ -74,37 +74,13 @@ func Configure(p *config.Provider) {
 
 		r.ServerSideApplyMergeStrategies["task"] = config.MergeStrategy{
 			ListMergeStrategy: config.ListMergeStrategy{
-				MergeStrategy: config.ListTypeMap,
 				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"taskKey"},
+					InjectedKey: config.InjectedKey{
+						Key:          "index",
+						DefaultValue: "default",
+					},
 				},
-			},
-		}
-
-		r.ServerSideApplyMergeStrategies["environment"] = config.MergeStrategy{
-			ListMergeStrategy: config.ListMergeStrategy{
 				MergeStrategy: config.ListTypeMap,
-				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"environmentKey"},
-				},
-			},
-		}
-
-		r.ServerSideApplyMergeStrategies["job_cluster"] = config.MergeStrategy{
-			ListMergeStrategy: config.ListMergeStrategy{
-				MergeStrategy: config.ListTypeMap,
-				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"jobClusterKey"},
-				},
-			},
-		}
-
-		r.ServerSideApplyMergeStrategies["task.depends_on"] = config.MergeStrategy{
-			ListMergeStrategy: config.ListMergeStrategy{
-				MergeStrategy: config.ListTypeMap,
-				ListMapKeys: config.ListMapKeys{
-					Keys: []string{"taskKey"},
-				},
 			},
 		}
 	})

--- a/package/crds/compute.databricks.crossplane.io_jobs.yaml
+++ b/package/crds/compute.databricks.crossplane.io_jobs.yaml
@@ -344,9 +344,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -936,9 +933,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -2240,9 +2234,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -4037,6 +4028,11 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -5701,7 +5697,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -6183,9 +6179,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -6777,9 +6770,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -8083,9 +8073,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -9882,6 +9869,11 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -11548,7 +11540,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -12032,9 +12024,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -12609,9 +12598,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -13591,9 +13577,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -15290,6 +15273,11 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -16327,7 +16315,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -16903,9 +16891,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -17421,9 +17406,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -18613,9 +18595,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -20194,6 +20173,11 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -21745,7 +21729,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -22197,9 +22181,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -22717,9 +22698,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -23911,9 +23889,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -25494,6 +25469,11 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -27047,7 +27027,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -27501,9 +27481,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -28005,9 +27982,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -28875,9 +28849,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -30361,6 +30332,11 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -31286,7 +31262,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run

--- a/package/crds/compute.databricks.m.crossplane.io_jobs.yaml
+++ b/package/crds/compute.databricks.m.crossplane.io_jobs.yaml
@@ -336,9 +336,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -923,9 +920,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -2247,9 +2241,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -4043,6 +4034,11 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -5753,7 +5749,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -6241,9 +6237,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -6830,9 +6823,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -8156,9 +8146,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -9954,6 +9941,11 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -11666,7 +11658,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -12122,9 +12114,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -12699,9 +12688,6 @@ spec:
                           type: array
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -13681,9 +13667,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -15380,6 +15363,11 @@ spec:
                                 type: array
                             type: object
                           type: array
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -16417,7 +16405,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -16985,9 +16973,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -17499,9 +17484,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -18711,9 +18693,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -20293,6 +20272,11 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -21888,7 +21872,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -22346,9 +22330,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -22862,9 +22843,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -24076,9 +24054,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -25660,6 +25635,11 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -27257,7 +27237,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run
@@ -27683,9 +27663,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - environmentKey
-                    x-kubernetes-list-type: map
                   existingClusterId:
                     description: 'Identifier of the interactive cluster to run job
                       on.  Note: running tasks on interactive clusters may lead to
@@ -28187,9 +28164,6 @@ spec:
                           type: object
                       type: object
                     type: array
-                    x-kubernetes-list-map-keys:
-                    - jobClusterKey
-                    x-kubernetes-list-type: map
                   library:
                     description: (List) An optional list of libraries to be installed
                       on the cluster that will execute the job. See library Configuration
@@ -29057,9 +29031,6 @@ spec:
                                 type: string
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                          - taskKey
-                          x-kubernetes-list-type: map
                         description:
                           description: An optional description for the job. The maximum
                             length is 1024 characters in UTF-8 encoding.
@@ -30543,6 +30514,11 @@ spec:
                                 type: object
                               type: array
                           type: object
+                        index:
+                          default: default
+                          description: This is an injected field with a default value
+                            for being able to merge items of the parent object list.
+                          type: string
                         jobClusterKey:
                           description: Identifier of the Job cluster specified in
                             the job_cluster block.
@@ -31468,7 +31444,7 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - taskKey
+                    - index
                     x-kubernetes-list-type: map
                   timeoutSeconds:
                     description: (Integer) An optional timeout applied to each run


### PR DESCRIPTION
- Introduced an `Index` field in TaskInitParameters, TaskObservation, and TaskParameters across v1alpha1 and v1beta1 APIs to facilitate merging of items in parent object lists.
- Updated DeepCopy methods to handle the new `Index` field.
- Adjusted job types to replace deprecated list map keys with the new `Index` key for tasks, environments, and job clusters.
- Modified server-side apply merge strategies to utilize the new `Index` field for better item merging.
- Updated CRDs to reflect the changes in the structure and added descriptions for the new `Index` field.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example


-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
