### PR TITLE
fix: moving pipeline state to status

### DIFF
--- a/apis/cluster/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/compute/v1alpha1/zz_generated.deepcopy.go
@@ -37473,11 +37473,6 @@ func (in *PipelineInitParameters) DeepCopyInto(out *PipelineInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
-		*out = new(string)
-		**out = **in
-	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(string)
@@ -38304,11 +38299,6 @@ func (in *PipelineParameters) DeepCopyInto(out *PipelineParameters) {
 	}
 	if in.ServerlessComputeID != nil {
 		in, out := &in.ServerlessComputeID, &out.ServerlessComputeID
-		*out = new(string)
-		**out = **in
-	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/cluster/compute/v1alpha1/zz_pipeline_types.go
+++ b/apis/cluster/compute/v1alpha1/zz_pipeline_types.go
@@ -3261,8 +3261,6 @@ type PipelineInitParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
 
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
-
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	Storage *string `json:"storage,omitempty" tf:"storage,omitempty"`
 
@@ -3614,9 +3612,6 @@ type PipelineParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	// +kubebuilder:validation:Optional
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
 
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	// +kubebuilder:validation:Optional

--- a/apis/cluster/compute/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/compute/v1beta1/zz_generated.deepcopy.go
@@ -35973,11 +35973,6 @@ func (in *PipelineInitParameters) DeepCopyInto(out *PipelineInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
-		*out = new(string)
-		**out = **in
-	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(string)
@@ -36740,11 +36735,6 @@ func (in *PipelineParameters) DeepCopyInto(out *PipelineParameters) {
 	}
 	if in.ServerlessComputeID != nil {
 		in, out := &in.ServerlessComputeID, &out.ServerlessComputeID
-		*out = new(string)
-		**out = **in
-	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/cluster/compute/v1beta1/zz_pipeline_types.go
+++ b/apis/cluster/compute/v1beta1/zz_pipeline_types.go
@@ -3261,8 +3261,6 @@ type PipelineInitParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
 
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
-
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	Storage *string `json:"storage,omitempty" tf:"storage,omitempty"`
 
@@ -3614,9 +3612,6 @@ type PipelineParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	// +kubebuilder:validation:Optional
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
 
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/compute/v1alpha1/zz_generated.deepcopy.go
@@ -37473,11 +37473,6 @@ func (in *PipelineInitParameters) DeepCopyInto(out *PipelineInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
-		*out = new(string)
-		**out = **in
-	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(string)
@@ -38304,11 +38299,6 @@ func (in *PipelineParameters) DeepCopyInto(out *PipelineParameters) {
 	}
 	if in.ServerlessComputeID != nil {
 		in, out := &in.ServerlessComputeID, &out.ServerlessComputeID
-		*out = new(string)
-		**out = **in
-	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/namespaced/compute/v1alpha1/zz_pipeline_types.go
+++ b/apis/namespaced/compute/v1alpha1/zz_pipeline_types.go
@@ -3261,8 +3261,6 @@ type PipelineInitParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
 
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
-
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	Storage *string `json:"storage,omitempty" tf:"storage,omitempty"`
 
@@ -3614,9 +3612,6 @@ type PipelineParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	// +kubebuilder:validation:Optional
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
 
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/compute/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/compute/v1beta1/zz_generated.deepcopy.go
@@ -35973,11 +35973,6 @@ func (in *PipelineInitParameters) DeepCopyInto(out *PipelineInitParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
-		*out = new(string)
-		**out = **in
-	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(string)
@@ -36740,11 +36735,6 @@ func (in *PipelineParameters) DeepCopyInto(out *PipelineParameters) {
 	}
 	if in.ServerlessComputeID != nil {
 		in, out := &in.ServerlessComputeID, &out.ServerlessComputeID
-		*out = new(string)
-		**out = **in
-	}
-	if in.State != nil {
-		in, out := &in.State, &out.State
 		*out = new(string)
 		**out = **in
 	}

--- a/apis/namespaced/compute/v1beta1/zz_pipeline_types.go
+++ b/apis/namespaced/compute/v1beta1/zz_pipeline_types.go
@@ -3261,8 +3261,6 @@ type PipelineInitParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
 
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
-
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	Storage *string `json:"storage,omitempty" tf:"storage,omitempty"`
 
@@ -3614,9 +3612,6 @@ type PipelineParameters struct {
 	// Canonical unique identifier of the Lakeflow Declarative Pipeline.
 	// +kubebuilder:validation:Optional
 	ServerlessComputeID *string `json:"serverlessComputeId,omitempty" tf:"serverless_compute_id,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	State *string `json:"state,omitempty" tf:"state,omitempty"`
 
 	// to catalog or vice versa.  If pipeline was already created with catalog set, the value could be changed.
 	// +kubebuilder:validation:Optional

--- a/config/cluster/pipeline/config.go
+++ b/config/cluster/pipeline/config.go
@@ -9,5 +9,11 @@ func Configure(p *config.Provider) {
 		r.ExternalName.OmittedFields = []string{
 			"last_modified",
 		}
+
+		// Move the state field to computed so that it is not required in the spec.
+		if s, ok := r.TerraformResource.Schema["state"]; ok {
+			s.Optional = false
+			s.Computed = true
+		}
 	})
 }

--- a/config/namespaced/pipeline/config.go
+++ b/config/namespaced/pipeline/config.go
@@ -10,5 +10,11 @@ func Configure(p *config.Provider) {
 		r.ExternalName.OmittedFields = []string{
 			"last_modified",
 		}
+
+		// Move the state field to computed so that it is not required in the spec.
+		if s, ok := r.TerraformResource.Schema["state"]; ok {
+			s.Optional = false
+			s.Computed = true
+		}
 	})
 }

--- a/package/crds/compute.databricks.crossplane.io_pipelines.yaml
+++ b/package/crds/compute.databricks.crossplane.io_pipelines.yaml
@@ -2090,8 +2090,6 @@ spec:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
                     type: string
-                  state:
-                    type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already
                       created with catalog set, the value could be changed.
@@ -4166,8 +4164,6 @@ spec:
                   serverlessComputeId:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
-                    type: string
-                  state:
                     type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already
@@ -8211,8 +8207,6 @@ spec:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
                     type: string
-                  state:
-                    type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already
                       created with catalog set, the value could be changed.
@@ -10056,8 +10050,6 @@ spec:
                   serverlessComputeId:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
-                    type: string
-                  state:
                     type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already

--- a/package/crds/compute.databricks.m.crossplane.io_pipelines.yaml
+++ b/package/crds/compute.databricks.m.crossplane.io_pipelines.yaml
@@ -2082,8 +2082,6 @@ spec:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
                     type: string
-                  state:
-                    type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already
                       created with catalog set, the value could be changed.
@@ -4164,8 +4162,6 @@ spec:
                   serverlessComputeId:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
-                    type: string
-                  state:
                     type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already
@@ -8173,8 +8169,6 @@ spec:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
                     type: string
-                  state:
-                    type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already
                       created with catalog set, the value could be changed.
@@ -10024,8 +10018,6 @@ spec:
                   serverlessComputeId:
                     description: Canonical unique identifier of the Lakeflow Declarative
                       Pipeline.
-                    type: string
-                  state:
                     type: string
                   storage:
                     description: to catalog or vice versa.  If pipeline was already


### PR DESCRIPTION
### Description of your changes

Fixes #
- Moving [pipeline_resource](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/pipeline) > state field from spec to stats. This field is computed only

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Deployed locally with `make e2e`
