### PR TITLE
fix: service principal display name diff exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 ![CI](https://github.com/glalanne/provider-databricks/workflows/CI/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/glalanne/provider-databricks/all.svg)](https://github.com/glalanne/provider-databricks/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/glalanne/provider-databricks)](https://goreportcard.com/report/github.com/glalanne/provider-databricks)
 [![Contributors](https://img.shields.io/github/contributors/glalanne/provider-databricks)](https://github.com/glalanne/provider-databricks/graphs/contributors)
 
 
@@ -24,7 +23,7 @@ Most of the testing have been done on [Azure Databricks](https://azure.microsoft
 Install the provider by using the following command after changing the image tag
 to the [latest release](https://marketplace.upbound.io/providers/lalanne/provider-databricks):
 ```
-up ctp provider install xpkg.upbound.io/lalanne/provider-databricks:v2.4.0
+up ctp provider install xpkg.upbound.io/lalanne/provider-databricks:v2.5.0
 ```
 
 Alternatively, you can use declarative installation:
@@ -35,7 +34,7 @@ kind: Provider
 metadata:
   name: provider-databricks
 spec:
-  package: xpkg.upbound.io/lalanne/provider-databricks:v2.4.0
+  package: xpkg.upbound.io/lalanne/provider-databricks:v2.5.0
 EOF
 ```
 

--- a/config/cluster/service_principal/config.go
+++ b/config/cluster/service_principal/config.go
@@ -1,10 +1,30 @@
 package service_principal
 
-import "github.com/crossplane/upjet/v2/pkg/config"
+import (
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("databricks_service_principal", func(r *config.Resource) {
 		r.ShortGroup = "security"
+
+		// The Databricks SCIM API cannot update displayName of an existing
+		// service principal, so drop it from the diff after creation.
+		// https://community.databricks.com/t5/administration-architecture/how-to-change-the-display-name-for-a-service-principal/td-p/139696
+		r.TerraformCustomDiff = func(
+			diff *terraform.InstanceDiff,
+			state *terraform.InstanceState,
+			cfg *terraform.ResourceConfig,
+		) (*terraform.InstanceDiff, error) {
+			if diff == nil || diff.Destroy || state == nil || state.ID == "" {
+				return diff, nil
+			}
+
+			delete(diff.Attributes, "display_name")
+
+			return diff, nil
+		}
 	})
 }

--- a/config/namespaced/service_principal/config.go
+++ b/config/namespaced/service_principal/config.go
@@ -1,10 +1,29 @@
 package service_principal
 
-import "github.com/crossplane/upjet/v2/pkg/config"
+import (
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("databricks_service_principal", func(r *config.Resource) {
 		r.ShortGroup = "security"
+
+		// The Databricks SCIM API cannot update displayName of an existing
+		// service principal, so drop it from the diff after creation.
+		r.TerraformCustomDiff = func(
+			diff *terraform.InstanceDiff,
+			state *terraform.InstanceState,
+			cfg *terraform.ResourceConfig,
+		) (*terraform.InstanceDiff, error) {
+			if diff == nil || diff.Destroy || state == nil || state.ID == "" {
+				return diff, nil
+			}
+
+			delete(diff.Attributes, "display_name")
+
+			return diff, nil
+		}
 	})
 }


### PR DESCRIPTION
### Description of your changes

This fix is excluding the display name from the TF Diff, because the Databricks SCIM Patch API silently fail/ignore
(for more details: [How to change the display name for a Service Principal](https://community.databricks.com/t5/administration-architecture/how-to-change-the-display-name-for-a-service-principal/td-p/139696)

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Local
