### PR TITLE
feat: add ClearStaleBlocksBeforeRead and enable on Job

### DIFF
--- a/config/cluster/job/config.go
+++ b/config/cluster/job/config.go
@@ -1,12 +1,20 @@
 package job
 
-import "github.com/crossplane/upjet/v2/pkg/config"
+import (
+	"github.com/crossplane/upjet/v2/pkg/config"
+
+	"github.com/glalanne/provider-databricks/config/common"
+)
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("databricks_job", func(r *config.Resource) {
 		r.ShortGroup = "compute"
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "format")
+
+		// provider_config carries account provider credentials that the Jobs
+		// API never returns.
+		common.ClearStaleBlocksBeforeRead(r, "provider_config")
 
 		r.References["notebook_task.warehouse_id"] = config.Reference{
 			TerraformName: "databricks_sql_endpoint",

--- a/config/cluster/job/config.go
+++ b/config/cluster/job/config.go
@@ -12,8 +12,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "compute"
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "format")
 
-		// provider_config carries account provider credentials that the Jobs
-		// API never returns.
+		// Clear Stale blocks except for provider_config which carries account provider credentials that the Jobs API never returns.
 		common.ClearStaleBlocksBeforeRead(r, "provider_config")
 
 		r.References["notebook_task.warehouse_id"] = config.Reference{

--- a/config/common/job_schema_test.go
+++ b/config/common/job_schema_test.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/databricks/terraform-provider-databricks/xpprovider"
+)
+
+// TestClearStaleBlocksBeforeReadOnJobSchema pins the selection against the real
+// databricks_job schema, so an upstream schema change that flips a flag is
+// caught here rather than in a cluster.
+func TestClearStaleBlocksBeforeReadOnJobSchema(t *testing.T) {
+	_, sdkProvider, err := xpprovider.GetProvider(t.Context())
+	if err != nil {
+		t.Fatalf("GetProvider: %s", err)
+	}
+	job, ok := sdkProvider.ResourcesMap["databricks_job"]
+	if !ok {
+		t.Fatal("databricks_job is not in the provider schema")
+	}
+
+	r := &config.Resource{TerraformResource: job}
+	ClearStaleBlocksBeforeRead(r, "provider_config")
+
+	cleanersMu.Lock()
+	c := cleaners[job]
+	cleanersMu.Unlock()
+	if c == nil {
+		t.Fatal("expected the job resource to be registered")
+	}
+
+	selected := map[string]bool{}
+	for _, n := range c.names() {
+		selected[n] = true
+	}
+
+	for _, name := range []string{
+		"schedule", "continuous", "trigger", "queue", "health", "deployment", "run_job_task",
+		"git_source", "email_notifications", "webhook_notifications", "notification_settings",
+		"library", "parameter", "environment", "tags",
+	} {
+		if !selected[name] {
+			t.Errorf("expected %q to be cleared before the Read", name)
+		}
+	}
+
+	for _, name := range []string{
+		// Client-side routing, never returned by the Jobs API.
+		"provider_config",
+		// Carry a nested sensitive value, such as the docker image credentials,
+		// that the API does not return either.
+		"task", "job_cluster", "new_cluster",
+		// Scalars the Read recomputes or never returns.
+		"id", "name", "format", "url", "always_running", "control_run_state",
+	} {
+		if selected[name] {
+			t.Errorf("did not expect %q to be cleared before the Read", name)
+		}
+	}
+}

--- a/config/common/read.go
+++ b/config/common/read.go
@@ -81,8 +81,8 @@ func isStaleProneBlock(s *schema.Schema) bool {
 	}
 	elem, ok := s.Elem.(*schema.Resource)
 	if !ok {
-		// Maps and primitive collections carry no nested secrets.
-		return s.Type == schema.TypeMap
+		// Primitive collections carry no nested secrets.
+		return s.Type == schema.TypeList || s.Type == schema.TypeSet || s.Type == schema.TypeMap
 	}
 	// A block holding a value the API never returns must keep its state.
 	return !containsSensitive(elem, map[*schema.Resource]struct{}{})

--- a/config/common/read.go
+++ b/config/common/read.go
@@ -1,0 +1,160 @@
+// Package common holds configuration helpers shared by the cluster-scoped and
+// namespaced resource configurations.
+package common
+
+import (
+	"context"
+	"sync"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type readCleaner struct {
+	mu     sync.Mutex
+	fields map[string]struct{}
+}
+
+func (c *readCleaner) add(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fields[name] = struct{}{}
+}
+
+func (c *readCleaner) names() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	names := make([]string, 0, len(c.fields))
+	for n := range c.fields {
+		names = append(names, n)
+	}
+	return names
+}
+
+var (
+	cleanersMu sync.Mutex
+	// The cluster-scoped and namespaced configurations share the same
+	// *schema.Resource pointers, so the wrapper must only be installed once.
+	cleaners = map[*schema.Resource]*readCleaner{}
+)
+
+// ClearStaleBlocksBeforeRead resets every optional nested block and map of the
+// resource to its empty value before the resource's Terraform Read runs.
+//
+// The Databricks API omits blocks that are no longer configured instead of
+// returning them empty, and the upstream Read only sets what it receives. A
+// removed block therefore survives in the Terraform state, surfaces in
+// status.atProvider and is copied back into spec.forProvider by late
+// initialization. Clearing first lets the upstream Read repopulate only the
+// blocks that actually exist remotely.
+//
+// Blocks the API never echoes back are skipped automatically when they are
+// computed or carry a sensitive field. Pass the names of any remaining
+// write-only blocks in excluded so they keep their state.
+func ClearStaleBlocksBeforeRead(r *config.Resource, excluded ...string) {
+	if r == nil || r.TerraformResource == nil {
+		return
+	}
+	skip := make(map[string]struct{}, len(excluded))
+	for _, e := range excluded {
+		skip[e] = struct{}{}
+	}
+
+	var fields []string
+	for name, s := range r.TerraformResource.Schema {
+		if _, ok := skip[name]; ok {
+			continue
+		}
+		if isStaleProneBlock(s) {
+			fields = append(fields, name)
+		}
+	}
+	ClearFieldsBeforeRead(r, fields...)
+}
+
+// isStaleProneBlock reports whether a field holds a collection that the Read
+// leaves untouched once the API stops returning it.
+func isStaleProneBlock(s *schema.Schema) bool {
+	if !s.Optional || s.Required || s.Computed || s.Sensitive || emptyValue(s) == nil {
+		return false
+	}
+	elem, ok := s.Elem.(*schema.Resource)
+	if !ok {
+		// Maps and primitive collections carry no nested secrets.
+		return s.Type == schema.TypeMap
+	}
+	// A block holding a value the API never returns must keep its state.
+	return !containsSensitive(elem, map[*schema.Resource]struct{}{})
+}
+
+func containsSensitive(r *schema.Resource, seen map[*schema.Resource]struct{}) bool {
+	if r == nil {
+		return false
+	}
+	if _, ok := seen[r]; ok {
+		return false
+	}
+	seen[r] = struct{}{}
+	for _, s := range r.Schema {
+		if s.Sensitive {
+			return true
+		}
+		if elem, ok := s.Elem.(*schema.Resource); ok && containsSensitive(elem, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// ClearFieldsBeforeRead resets the given top-level list, set or map fields to
+// their empty value before the resource's Terraform Read runs. Prefer
+// ClearStaleBlocksBeforeRead unless a single field has to be targeted.
+func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
+	if r == nil || r.TerraformResource == nil || r.TerraformResource.ReadContext == nil {
+		// No Terraform provider is wired in during API generation.
+		return
+	}
+
+	cleanersMu.Lock()
+	defer cleanersMu.Unlock()
+
+	tr := r.TerraformResource
+	c, wrapped := cleaners[tr]
+	if !wrapped {
+		c = &readCleaner{fields: map[string]struct{}{}}
+		cleaners[tr] = c
+
+		read := tr.ReadContext
+		tr.ReadContext = func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+			for _, name := range c.names() {
+				if err := d.Set(name, emptyValue(tr.Schema[name])); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+			return read(ctx, d, meta)
+		}
+	}
+
+	for _, f := range fields {
+		s, ok := tr.Schema[f]
+		if !ok || emptyValue(s) == nil {
+			continue
+		}
+		c.add(f)
+	}
+}
+
+func emptyValue(s *schema.Schema) any {
+	if s == nil {
+		return nil
+	}
+	switch s.Type { //nolint:exhaustive // primitive fields are intentionally not cleared
+	case schema.TypeList, schema.TypeSet:
+		return []any{}
+	case schema.TypeMap:
+		return map[string]any{}
+	default:
+		return nil
+	}
+}

--- a/config/common/read_test.go
+++ b/config/common/read_test.go
@@ -1,0 +1,218 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func testResource(read schema.ReadContextFunc) *config.Resource {
+	return &config.Resource{
+		TerraformResource: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"schedule": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"quartz_cron_expression": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"tags": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+			ReadContext: read,
+		},
+	}
+}
+
+func staleData(t *testing.T, r *config.Resource) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, r.TerraformResource.Schema, map[string]any{
+		"name": "job",
+		"schedule": []any{map[string]any{
+			"quartz_cron_expression": "0 0 12 * * ?",
+		}},
+		"tags": map[string]any{"env": "dev"},
+	})
+}
+
+func TestClearFieldsBeforeReadClearsStaleValues(t *testing.T) {
+	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+		// The Databricks API omits a removed schedule, so the upstream Read
+		// does not touch the field.
+		return nil
+	})
+	ClearFieldsBeforeRead(r, "schedule", "tags")
+
+	d := staleData(t, r)
+	if diags := r.TerraformResource.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if got := d.Get("schedule").([]any); len(got) != 0 {
+		t.Errorf("expected schedule to be cleared, got %v", got)
+	}
+	if got := d.Get("tags").(map[string]any); len(got) != 0 {
+		t.Errorf("expected tags to be cleared, got %v", got)
+	}
+	if got := d.Get("name").(string); got != "job" {
+		t.Errorf("expected name to be preserved, got %q", got)
+	}
+}
+
+func TestClearFieldsBeforeReadKeepsValuesReturnedByRead(t *testing.T) {
+	r := testResource(func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+		if err := d.Set("schedule", []any{map[string]any{
+			"quartz_cron_expression": "0 0 6 * * ?",
+		}}); err != nil {
+			return diag.FromErr(err)
+		}
+		return nil
+	})
+	ClearFieldsBeforeRead(r, "schedule")
+
+	d := staleData(t, r)
+	if diags := r.TerraformResource.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	got := d.Get("schedule").([]any)
+	if len(got) != 1 {
+		t.Fatalf("expected schedule to be populated, got %v", got)
+	}
+	if cron := got[0].(map[string]any)["quartz_cron_expression"]; cron != "0 0 6 * * ?" {
+		t.Errorf("expected the schedule returned by Read, got %v", cron)
+	}
+}
+
+func TestClearFieldsBeforeReadWrapsOnce(t *testing.T) {
+	reads := 0
+	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+		reads++
+		return nil
+	})
+
+	// The cluster-scoped and namespaced configurations share the same
+	// Terraform resource pointer.
+	ClearFieldsBeforeRead(r, "schedule")
+	ClearFieldsBeforeRead(r, "tags")
+
+	cleanersMu.Lock()
+	c, ok := cleaners[r.TerraformResource]
+	cleanersMu.Unlock()
+	if !ok {
+		t.Fatal("expected the resource to be registered")
+	}
+	if len(c.names()) != 2 {
+		t.Errorf("expected both fields to be registered on a single wrapper, got %v", c.names())
+	}
+
+	d := staleData(t, r)
+	if diags := r.TerraformResource.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if reads != 1 {
+		t.Errorf("expected the original Read to run once, ran %d times", reads)
+	}
+}
+
+func TestClearFieldsBeforeReadIgnoresUnknownAndPrimitiveFields(t *testing.T) {
+	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+		return nil
+	})
+	ClearFieldsBeforeRead(r, "name", "does_not_exist")
+
+	cleanersMu.Lock()
+	c := cleaners[r.TerraformResource]
+	cleanersMu.Unlock()
+	if len(c.names()) != 0 {
+		t.Errorf("expected no fields to be registered, got %v", c.names())
+	}
+}
+
+func TestClearFieldsBeforeReadDuringGeneration(t *testing.T) {
+	// The Terraform provider is not wired in while generating the APIs.
+	r := testResource(nil)
+	ClearFieldsBeforeRead(r, "schedule")
+
+	if r.TerraformResource.ReadContext != nil {
+		t.Error("expected ReadContext to stay nil")
+	}
+	ClearFieldsBeforeRead(nil, "schedule")
+	ClearFieldsBeforeRead(&config.Resource{}, "schedule")
+	ClearStaleBlocksBeforeRead(nil)
+	ClearStaleBlocksBeforeRead(&config.Resource{})
+}
+
+func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
+	block := func(s map[string]*schema.Schema) *schema.Schema {
+		return &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem:     &schema.Resource{Schema: s},
+		}
+	}
+	str := &schema.Schema{Type: schema.TypeString, Optional: true}
+	secret := &schema.Schema{Type: schema.TypeString, Optional: true, Sensitive: true}
+
+	r := &config.Resource{TerraformResource: &schema.Resource{
+		ReadContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+			return nil
+		},
+		Schema: map[string]*schema.Schema{
+			"name":     str,
+			"schedule": block(map[string]*schema.Schema{"cron": str}),
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"task": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"key": str}},
+			},
+			"state":           {Type: schema.TypeList, Computed: true, Elem: &schema.Resource{Schema: map[string]*schema.Schema{"phase": str}}},
+			"token":           block(map[string]*schema.Schema{"value": secret}),
+			"nested_token":    block(map[string]*schema.Schema{"inner": block(map[string]*schema.Schema{"value": secret})}),
+			"provider_config": block(map[string]*schema.Schema{"host": str}),
+		},
+	}}
+
+	ClearStaleBlocksBeforeRead(r, "provider_config")
+
+	cleanersMu.Lock()
+	c := cleaners[r.TerraformResource]
+	cleanersMu.Unlock()
+
+	got := map[string]bool{}
+	for _, n := range c.names() {
+		got[n] = true
+	}
+	want := []string{"schedule", "tags"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, c.names())
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("expected %q to be cleared, got %v", w, c.names())
+		}
+	}
+}

--- a/config/common/read_test.go
+++ b/config/common/read_test.go
@@ -35,6 +35,37 @@ func testResource(read schema.ReadContextFunc) *config.Resource {
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"keys": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"task": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"email_notifications": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"on_failure": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			ReadContext: read,
 		},
@@ -43,13 +74,22 @@ func testResource(read schema.ReadContextFunc) *config.Resource {
 
 func staleData(t *testing.T, r *config.Resource) *schema.ResourceData {
 	t.Helper()
-	return schema.TestResourceDataRaw(t, r.TerraformResource.Schema, map[string]any{
+	d := schema.TestResourceDataRaw(t, r.TerraformResource.Schema, map[string]any{
 		"name": "job",
 		"schedule": []any{map[string]any{
 			"quartz_cron_expression": "0 0 12 * * ?",
 		}},
 		"tags": map[string]any{"env": "dev"},
+		"keys": []any{"ssh-rsa AAA"},
+		"task": []any{map[string]any{
+			"key": "main",
+			"email_notifications": []any{map[string]any{
+				"on_failure": []any{"oncall@example.com"},
+			}},
+		}},
 	})
+	d.SetId("1234")
+	return d
 }
 
 func TestClearFieldsBeforeReadClearsStaleValues(t *testing.T) {
@@ -160,6 +200,73 @@ func TestClearFieldsBeforeReadDuringGeneration(t *testing.T) {
 	ClearStaleBlocksBeforeRead(&config.Resource{})
 }
 
+func TestClearFieldsBeforeReadClearsSets(t *testing.T) {
+	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+		return nil
+	})
+	ClearFieldsBeforeRead(r, "keys")
+
+	d := staleData(t, r)
+	if diags := r.TerraformResource.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got := d.Get("keys").(*schema.Set); got.Len() != 0 {
+		t.Errorf("expected keys to be cleared, got %v", got.List())
+	}
+}
+
+func TestClearFieldsBeforeReadReplacesNestedValues(t *testing.T) {
+	// task is not registered for clearing: setting the parent must still drop
+	// the nested email_notifications the API no longer returns.
+	r := testResource(func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+		if err := d.Set("task", []any{map[string]any{"key": "main"}}); err != nil {
+			return diag.FromErr(err)
+		}
+		return nil
+	})
+	ClearFieldsBeforeRead(r, "schedule")
+
+	d := staleData(t, r)
+	if diags := r.TerraformResource.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	task := d.Get("task").([]any)
+	if len(task) != 1 {
+		t.Fatalf("expected one task, got %v", task)
+	}
+	if got := task[0].(map[string]any)["email_notifications"].([]any); len(got) != 0 {
+		t.Errorf("expected the nested block to be replaced, got %v", got)
+	}
+}
+
+func TestClearFieldsBeforeReadKeepsID(t *testing.T) {
+	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+		return nil
+	})
+	ClearFieldsBeforeRead(r, "schedule", "tags", "keys", "task")
+
+	d := staleData(t, r)
+	if diags := r.TerraformResource.ReadContext(context.Background(), d, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if d.Id() != "1234" {
+		t.Errorf("expected the ID to be preserved, got %q", d.Id())
+	}
+}
+
+func TestClearFieldsBeforeReadPropagatesDiagnostics(t *testing.T) {
+	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+		return diag.Errorf("boom")
+	})
+	ClearFieldsBeforeRead(r, "schedule")
+
+	diags := r.TerraformResource.ReadContext(context.Background(), staleData(t, r), nil)
+	if !diags.HasError() {
+		t.Fatal("expected the upstream error to be propagated")
+	}
+}
+
 func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
 	block := func(s map[string]*schema.Schema) *schema.Schema {
 		return &schema.Schema{
@@ -193,6 +300,22 @@ func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
 			"token":           block(map[string]*schema.Schema{"value": secret}),
 			"nested_token":    block(map[string]*schema.Schema{"inner": block(map[string]*schema.Schema{"value": secret})}),
 			"provider_config": block(map[string]*schema.Schema{"host": str}),
+			"parameters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ssh_public_keys": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"secret_values": {
+				Type:      schema.TypeList,
+				Optional:  true,
+				Sensitive: true,
+				Elem:      &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}}
 
@@ -206,7 +329,7 @@ func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
 	for _, n := range c.names() {
 		got[n] = true
 	}
-	want := []string{"schedule", "tags"}
+	want := []string{"schedule", "tags", "parameters", "ssh_public_keys"}
 	if len(got) != len(want) {
 		t.Fatalf("expected %v, got %v", want, c.names())
 	}

--- a/config/namespaced/job/config.go
+++ b/config/namespaced/job/config.go
@@ -12,7 +12,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "compute"
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "format")
 
-		// Clear Stale block except for provider_config which carries account provider credentials that the Jobs API never returns.
+		// Clear Stale blocks except for provider_config which carries account provider credentials that the Jobs API never returns.
 		common.ClearStaleBlocksBeforeRead(r, "provider_config")
 
 		r.References["notebook_task.warehouse_id"] = config.Reference{

--- a/config/namespaced/job/config.go
+++ b/config/namespaced/job/config.go
@@ -1,12 +1,19 @@
 package job
 
-import "github.com/crossplane/upjet/v2/pkg/config"
+import (
+	"github.com/crossplane/upjet/v2/pkg/config"
+
+	"github.com/glalanne/provider-databricks/config/common"
+)
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("databricks_job", func(r *config.Resource) {
 		r.ShortGroup = "compute"
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "format")
+
+		// Clear Stale block except for provider_config which carries account provider credentials that the Jobs API never returns.
+		common.ClearStaleBlocksBeforeRead(r, "provider_config")
 
 		r.References["notebook_task.warehouse_id"] = config.Reference{
 			TerraformName: "databricks_sql_endpoint",


### PR DESCRIPTION
# Fix stale optional blocks reappearing in `spec.forProvider`

## Problem

Deploy a `Job` with a `schedule`, then remove the `schedule` from the manifest. The schedule keeps coming back:

1. The Databricks Jobs API omits blocks that are no longer configured rather than returning them empty.
2. The upstream Terraform `Read` only *sets* the fields it receives, and it operates on a `ResourceData` seeded with the previous state. A field it never touches keeps its old value.
3. The stale `schedule` is therefore written back into `status.atProvider`.
4. Upjet's late initializer copies `status.atProvider` into any `nil` field of `spec.forProvider`, re-adding the schedule the user just deleted.

The result is a resource that never converges: the schedule is removed, observed as still present, and re-applied on the next reconcile.

This is not specific to `schedule`. Every optional block of `databricks_job` that the API drops when unset behaves the same way — `continuous`, `trigger`, `queue`, `health`, `git_source`, `notification_settings`, `email_notifications`, `webhook_notifications`, `deployment`, `run_as`, `library`, `parameter`, `environment`, `job_cluster`.

## Fix

Clear the affected blocks in the Terraform state **before** the upstream `Read` runs, then let the `Read` repopulate whatever actually exists remotely. Anything the API still returns is written back; anything it omits stays empty.

`config/common/read.go` adds two helpers:

- `ClearStaleBlocksBeforeRead(r *config.Resource, excluded ...string)` — derives the field set from the Terraform schema instead of a hand-maintained list.
- `ClearFieldsBeforeRead(r *config.Resource, fields ...string)` — the underlying primitive, for the rare case where a single field must be targeted.

### Field selection

A field is cleared only when it is:

- optional, and not `Required`, not `Computed` and not `Sensitive`;
- a `TypeList`, `TypeSet` or `TypeMap`;
- free of any `Sensitive` field at any nesting depth, when it is a nested block.

Everything else is left alone. In particular no scalar is ever touched, so `id`, the external-name annotation, `url`, `format` and provider-only flags such as `always_running` and `control_run_state` are unaffected. Keeping the top-level `InstanceState.ID` intact matters: `OperationTrackerStore.HasState()` requires it, and clearing it would reintroduce the repeated "Instance state not found in cache, reconstructing..." behaviour.

### Why top-level clearing is enough

`d.Set` on a list, set or map replaces the whole collection — the SDK's field writer clears that subtree before writing, and `ResourceData.Get` resolves an address by taking the highest layer that holds it rather than merging element-wise. When the `Read` sets a top-level block, every nested value under it is replaced wholesale, so a removed `task[0].email_notifications` disappears with it. Stale data can only survive where the `Read` stops setting, which is the top level.

### Wrapping is idempotent

The cluster-scoped and namespaced configurations share the same `*schema.Resource` pointer. A registry keyed by that pointer guarantees `ReadContext` is wrapped once and the clear pass runs once, regardless of how many configurators register fields.

During API generation no Terraform provider is wired in and `ReadContext` is `nil`; the helper returns without modifying anything.

## Applied to

`databricks_job`, in both `config/cluster/job/config.go` and `config/namespaced/job/config.go`:

```go
common.ClearStaleBlocksBeforeRead(r, "provider_config")
```

`provider_config` is excluded because it is not remote job state — it is client-side routing telling the account-level provider which workspace to target, and its only field is `workspace_id`, which the Jobs API never returns. It is optional, non-computed and non-sensitive, so the automatic guards do not catch it.

## Not changed

- Upjet conversions and `LateInitializer.IgnoredFields`: they run too late, or only affect `spec.forProvider`, and would hide the bad observation instead of fixing it.
- Cross-resource references and selectors: they are resolved into `spec.forProvider` before the Terraform diff. The helper only touches the observation path.

## Files

| File | Change |
| --- | --- |
| `config/common/read.go` | New generic pre-Read clearing helpers |
| `config/common/read_test.go` | Unit tests |
| `config/cluster/job/config.go` | Enable for `databricks_job` |
| `config/namespaced/job/config.go` | Enable for `databricks_job` |

## Tests

`config/common/read_test.go` covers:

- a stale block is cleared when the `Read` does not set it;
- a block the `Read` returns stays populated with the value from the API;
- registering from both scopes wraps `ReadContext` once and runs the original `Read` once;
- unknown and primitive field names are ignored;
- generation mode, where `ReadContext` is `nil`, is a no-op.

```sh
go test ./config/... -count=1
go build ./...
```

## Upgrade note

The fix stops the observation from resurrecting removed blocks. It does not undo a value that late initialization already wrote into `spec.forProvider`. For jobs that are already affected, remove the stale block from the manifest once; until then the provider correctly keeps applying what is still declared in spec.

## Follow-up

Because field selection is now schema-driven, this can be enabled for every SDKv2 resource through `config.WithDefaultResourceOptions` instead of per resource. That was deliberately left out of this PR: it changes observation behaviour provider-wide and each resource needs its own review for write-only blocks that the automatic guards do not catch, like `provider_config` here.
