### PR TITLE
fix: replace ClearStaleBlocksBeforeRead with UseAuthoritativeRead

### DIFF
--- a/config/cluster/job/config.go
+++ b/config/cluster/job/config.go
@@ -12,8 +12,8 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "compute"
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "format")
 
-		// Clear Stale blocks except for provider_config which carries account provider credentials that the Jobs API never returns.
-		common.ClearStaleBlocksBeforeRead(r, "provider_config")
+		// Preserve schema-only and write-only lifecycle fields across reads.
+		common.UseAuthoritativeRead(r, "provider_config", "always_running", "control_run_state")
 
 		r.References["notebook_task.warehouse_id"] = config.Reference{
 			TerraformName: "databricks_sql_endpoint",

--- a/config/common/job_schema_test.go
+++ b/config/common/job_schema_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/databricks/terraform-provider-databricks/xpprovider"
 )
 
-// TestClearStaleBlocksBeforeReadOnJobSchema pins the selection against the real
+// TestUseAuthoritativeReadOnJobSchema pins the selection against the real
 // databricks_job schema, so an upstream schema change that flips a flag is
 // caught here rather than in a cluster.
-func TestClearStaleBlocksBeforeReadOnJobSchema(t *testing.T) {
+func TestUseAuthoritativeReadOnJobSchema(t *testing.T) {
 	_, sdkProvider, err := xpprovider.GetProvider(t.Context())
 	if err != nil {
 		t.Fatalf("GetProvider: %s", err)
@@ -21,7 +21,7 @@ func TestClearStaleBlocksBeforeReadOnJobSchema(t *testing.T) {
 	}
 
 	r := &config.Resource{TerraformResource: job}
-	ClearStaleBlocksBeforeRead(r, "provider_config")
+	UseAuthoritativeRead(r, "provider_config", "always_running", "control_run_state")
 
 	cleanersMu.Lock()
 	c := cleaners[job]
@@ -36,6 +36,7 @@ func TestClearStaleBlocksBeforeReadOnJobSchema(t *testing.T) {
 	}
 
 	for _, name := range []string{
+		"name", "description", "timeout_seconds", "max_retries", "max_concurrent_runs", "edit_mode",
 		"schedule", "continuous", "trigger", "queue", "health", "deployment", "run_job_task",
 		"git_source", "email_notifications", "webhook_notifications", "notification_settings",
 		"library", "parameter", "environment", "tags",
@@ -51,8 +52,8 @@ func TestClearStaleBlocksBeforeReadOnJobSchema(t *testing.T) {
 		// Carry a nested sensitive value, such as the docker image credentials,
 		// that the API does not return either.
 		"task", "job_cluster", "new_cluster",
-		// Scalars the Read recomputes or never returns.
-		"id", "name", "format", "url", "always_running", "control_run_state",
+		// Computed fields and write-only lifecycle controls.
+		"id", "format", "url", "always_running", "control_run_state",
 	} {
 		if selected[name] {
 			t.Errorf("did not expect %q to be cleared before the Read", name)

--- a/config/common/read.go
+++ b/config/common/read.go
@@ -108,8 +108,8 @@ func containsSensitive(r *schema.Resource, seen map[*schema.Resource]struct{}) b
 }
 
 // ClearFieldsBeforeRead resets the given top-level list, set or map fields to
-// their empty value before the resource's Terraform Read runs. Prefer
-// ClearStaleBlocksBeforeRead unless a single field has to be targeted.
+// their empty value if the resource's Terraform Read does not populate them.
+// Prefer ClearStaleBlocksBeforeRead unless a single field has to be targeted.
 func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
 	if r == nil || r.TerraformResource == nil || r.TerraformResource.ReadContext == nil {
 		// No Terraform provider is wired in during API generation.
@@ -127,12 +127,21 @@ func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
 
 		read := tr.ReadContext
 		tr.ReadContext = func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-			for _, name := range c.names() {
-				if err := d.Set(name, emptyValue(tr.Schema[name])); err != nil {
+			names := c.names()
+			for _, name := range names {
+				if err := d.Set(name, sentinelValue(tr.Schema[name])); err != nil {
 					return diag.FromErr(err)
 				}
 			}
-			return read(ctx, d, meta)
+			diags := read(ctx, d, meta)
+			for _, name := range names {
+				if isSentinel(tr.Schema[name], d.Get(name)) {
+					if err := d.Set(name, emptyValue(tr.Schema[name])); err != nil {
+						return diag.FromErr(err)
+					}
+				}
+			}
+			return diags
 		}
 	}
 
@@ -143,6 +152,68 @@ func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
 		}
 		c.add(f)
 	}
+}
+
+func sentinelValue(s *schema.Schema) any {
+	if s == nil {
+		return nil
+	}
+	switch s.Type { //nolint:exhaustive // primitive fields are intentionally not cleared
+	case schema.TypeList, schema.TypeSet:
+		if elem, ok := s.Elem.(*schema.Resource); ok {
+			m := map[string]any{}
+			for k, fs := range elem.Schema {
+				if fs.Type == schema.TypeString && !fs.Required {
+					m[k] = ""
+					break
+				}
+			}
+			if len(m) > 0 {
+				return []any{m}
+			}
+		}
+		return []any{""}
+	case schema.TypeMap:
+		return map[string]any{"": ""}
+	default:
+		return nil
+	}
+}
+
+func isSentinel(s *schema.Schema, v any) bool {
+	if s == nil || v == nil {
+		return false
+	}
+	switch s.Type {
+	case schema.TypeList, schema.TypeSet:
+		if elem, ok := s.Elem.(*schema.Resource); ok {
+			list, _ := v.([]any)
+			if set, ok := v.(*schema.Set); ok {
+				list = set.List()
+			}
+			if len(list) == 1 {
+				if m, ok := list[0].(map[string]any); ok {
+					for k, fs := range elem.Schema {
+						if fs.Type == schema.TypeString && !fs.Required {
+							val, exists := m[k]
+							return exists && val == ""
+						}
+					}
+				}
+			}
+			return false
+		}
+		list, _ := v.([]any)
+		if set, ok := v.(*schema.Set); ok {
+			list = set.List()
+		}
+		return len(list) == 1 && list[0] == ""
+	case schema.TypeMap:
+		m, _ := v.(map[string]any)
+		val, exists := m[""]
+		return exists && val == ""
+	}
+	return false
 }
 
 func emptyValue(s *schema.Schema) any {

--- a/config/common/read.go
+++ b/config/common/read.go
@@ -165,7 +165,8 @@ func emptyValue(s *schema.Schema) any {
 		return []any{}
 	case schema.TypeMap:
 		return map[string]any{}
-	default:
+	case schema.TypeInvalid:
 		return nil
 	}
+	return nil
 }

--- a/config/common/read.go
+++ b/config/common/read.go
@@ -39,20 +39,22 @@ var (
 	cleaners = map[*schema.Resource]*readCleaner{}
 )
 
-// ClearStaleBlocksBeforeRead resets every optional nested block and map of the
-// resource to its empty value before the resource's Terraform Read runs.
+// UseAuthoritativeRead makes the API response authoritative for every
+// optional field that is safe to clear before the resource's Terraform Read.
 //
-// The Databricks API omits blocks that are no longer configured instead of
+// The Databricks API omits fields that are no longer configured instead of
 // returning them empty, and the upstream Read only sets what it receives. A
-// removed block therefore survives in the Terraform state, surfaces in
+// removed field therefore survives in the Terraform state, surfaces in
 // status.atProvider and is copied back into spec.forProvider by late
 // initialization. Clearing first lets the upstream Read repopulate only the
-// blocks that actually exist remotely.
+// fields that actually exist remotely. Marking the temporary ResourceData as
+// new makes StructToData populate fields returned by the API even when they
+// are absent from config.
 //
-// Blocks the API never echoes back are skipped automatically when they are
+// Fields the API never echoes back are skipped automatically when they are
 // computed or carry a sensitive field. Pass the names of any remaining
-// write-only blocks in excluded so they keep their state.
-func ClearStaleBlocksBeforeRead(r *config.Resource, excluded ...string) {
+// write-only fields in excluded so they keep their state.
+func UseAuthoritativeRead(r *config.Resource, excluded ...string) {
 	if r == nil || r.TerraformResource == nil {
 		return
 	}
@@ -66,23 +68,22 @@ func ClearStaleBlocksBeforeRead(r *config.Resource, excluded ...string) {
 		if _, ok := skip[name]; ok {
 			continue
 		}
-		if isStaleProneBlock(s) {
+		if isStaleProneField(s) {
 			fields = append(fields, name)
 		}
 	}
 	ClearFieldsBeforeRead(r, fields...)
 }
 
-// isStaleProneBlock reports whether a field holds a collection that the Read
-// leaves untouched once the API stops returning it.
-func isStaleProneBlock(s *schema.Schema) bool {
+// isStaleProneField reports whether a field can be cleared before Read and
+// reconstructed from the API response.
+func isStaleProneField(s *schema.Schema) bool {
 	if !s.Optional || s.Required || s.Computed || s.Sensitive || emptyValue(s) == nil {
 		return false
 	}
 	elem, ok := s.Elem.(*schema.Resource)
 	if !ok {
-		// Primitive collections carry no nested secrets.
-		return s.Type == schema.TypeList || s.Type == schema.TypeSet || s.Type == schema.TypeMap
+		return true
 	}
 	// A block holding a value the API never returns must keep its state.
 	return !containsSensitive(elem, map[*schema.Resource]struct{}{})
@@ -107,9 +108,9 @@ func containsSensitive(r *schema.Resource, seen map[*schema.Resource]struct{}) b
 	return false
 }
 
-// ClearFieldsBeforeRead resets the given top-level list, set or map fields to
+// ClearFieldsBeforeRead resets the given top-level fields to
 // their empty value if the resource's Terraform Read does not populate them.
-// Prefer ClearStaleBlocksBeforeRead unless a single field has to be targeted.
+// Prefer UseAuthoritativeRead unless a single field has to be targeted.
 func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
 	if r == nil || r.TerraformResource == nil || r.TerraformResource.ReadContext == nil {
 		// No Terraform provider is wired in during API generation.
@@ -129,19 +130,12 @@ func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
 		tr.ReadContext = func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 			names := c.names()
 			for _, name := range names {
-				if err := d.Set(name, sentinelValue(tr.Schema[name])); err != nil {
+				if err := d.Set(name, emptyValue(tr.Schema[name])); err != nil {
 					return diag.FromErr(err)
 				}
 			}
-			diags := read(ctx, d, meta)
-			for _, name := range names {
-				if isSentinel(tr.Schema[name], d.Get(name)) {
-					if err := d.Set(name, emptyValue(tr.Schema[name])); err != nil {
-						return diag.FromErr(err)
-					}
-				}
-			}
-			return diags
+			d.MarkNewResource()
+			return read(ctx, d, meta)
 		}
 	}
 
@@ -154,73 +148,19 @@ func ClearFieldsBeforeRead(r *config.Resource, fields ...string) {
 	}
 }
 
-func sentinelValue(s *schema.Schema) any {
-	if s == nil {
-		return nil
-	}
-	switch s.Type { //nolint:exhaustive // primitive fields are intentionally not cleared
-	case schema.TypeList, schema.TypeSet:
-		if elem, ok := s.Elem.(*schema.Resource); ok {
-			m := map[string]any{}
-			for k, fs := range elem.Schema {
-				if fs.Type == schema.TypeString && !fs.Required {
-					m[k] = ""
-					break
-				}
-			}
-			if len(m) > 0 {
-				return []any{m}
-			}
-		}
-		return []any{""}
-	case schema.TypeMap:
-		return map[string]any{"": ""}
-	default:
-		return nil
-	}
-}
-
-func isSentinel(s *schema.Schema, v any) bool {
-	if s == nil || v == nil {
-		return false
-	}
-	switch s.Type {
-	case schema.TypeList, schema.TypeSet:
-		if elem, ok := s.Elem.(*schema.Resource); ok {
-			list, _ := v.([]any)
-			if set, ok := v.(*schema.Set); ok {
-				list = set.List()
-			}
-			if len(list) == 1 {
-				if m, ok := list[0].(map[string]any); ok {
-					for k, fs := range elem.Schema {
-						if fs.Type == schema.TypeString && !fs.Required {
-							val, exists := m[k]
-							return exists && val == ""
-						}
-					}
-				}
-			}
-			return false
-		}
-		list, _ := v.([]any)
-		if set, ok := v.(*schema.Set); ok {
-			list = set.List()
-		}
-		return len(list) == 1 && list[0] == ""
-	case schema.TypeMap:
-		m, _ := v.(map[string]any)
-		val, exists := m[""]
-		return exists && val == ""
-	}
-	return false
-}
-
 func emptyValue(s *schema.Schema) any {
 	if s == nil {
 		return nil
 	}
-	switch s.Type { //nolint:exhaustive // primitive fields are intentionally not cleared
+	switch s.Type {
+	case schema.TypeBool:
+		return false
+	case schema.TypeInt:
+		return 0
+	case schema.TypeFloat:
+		return float64(0)
+	case schema.TypeString:
+		return ""
 	case schema.TypeList, schema.TypeSet:
 		return []any{}
 	case schema.TypeMap:

--- a/config/common/read_test.go
+++ b/config/common/read_test.go
@@ -5,9 +5,18 @@ import (
 	"testing"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
+	tfcommon "github.com/databricks/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+type observedSchedule struct {
+	QuartzCronExpression string `json:"quartz_cron_expression,omitempty"`
+}
+
+type observedJob struct {
+	Schedule *observedSchedule `json:"schedule,omitempty"`
+}
 
 func testResource(read schema.ReadContextFunc) *config.Resource {
 	return &config.Resource{
@@ -93,10 +102,10 @@ func staleData(t *testing.T, r *config.Resource) *schema.ResourceData {
 }
 
 func TestClearFieldsBeforeReadClearsStaleValues(t *testing.T) {
-	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+	r := testResource(func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
 		// The Databricks API omits a removed schedule, so the upstream Read
 		// does not touch the field.
-		return nil
+		return diag.FromErr(tfcommon.StructToData(observedJob{}, observedJobSchema(), d))
 	})
 	ClearFieldsBeforeRead(r, "schedule", "tags")
 
@@ -116,14 +125,14 @@ func TestClearFieldsBeforeReadClearsStaleValues(t *testing.T) {
 	}
 }
 
-func TestClearFieldsBeforeReadKeepsValuesReturnedByRead(t *testing.T) {
+func TestUseAuthoritativeReadKeepsValuesReturnedByRead(t *testing.T) {
 	r := testResource(func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
-		if err := d.Set("schedule", []any{map[string]any{
-			"quartz_cron_expression": "0 0 6 * * ?",
-		}}); err != nil {
-			return diag.FromErr(err)
+		if !d.IsNewResource() {
+			return diag.Errorf("expected authoritative Read to be marked as new")
 		}
-		return nil
+		return diag.FromErr(tfcommon.StructToData(observedJob{Schedule: &observedSchedule{
+			QuartzCronExpression: "0 0 6 * * ?",
+		}}, observedJobSchema(), d))
 	})
 	ClearFieldsBeforeRead(r, "schedule")
 
@@ -138,6 +147,19 @@ func TestClearFieldsBeforeReadKeepsValuesReturnedByRead(t *testing.T) {
 	}
 	if cron := got[0].(map[string]any)["quartz_cron_expression"]; cron != "0 0 6 * * ?" {
 		t.Errorf("expected the schedule returned by Read, got %v", cron)
+	}
+}
+
+func observedJobSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"schedule": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+				"quartz_cron_expression": {Type: schema.TypeString, Optional: true},
+			}},
+		},
 	}
 }
 
@@ -172,7 +194,7 @@ func TestClearFieldsBeforeReadWrapsOnce(t *testing.T) {
 	}
 }
 
-func TestClearFieldsBeforeReadIgnoresUnknownAndPrimitiveFields(t *testing.T) {
+func TestClearFieldsBeforeReadSupportsPrimitiveFields(t *testing.T) {
 	r := testResource(func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
 		return nil
 	})
@@ -181,8 +203,8 @@ func TestClearFieldsBeforeReadIgnoresUnknownAndPrimitiveFields(t *testing.T) {
 	cleanersMu.Lock()
 	c := cleaners[r.TerraformResource]
 	cleanersMu.Unlock()
-	if len(c.names()) != 0 {
-		t.Errorf("expected no fields to be registered, got %v", c.names())
+	if names := c.names(); len(names) != 1 || names[0] != "name" {
+		t.Errorf("expected only name to be registered, got %v", names)
 	}
 }
 
@@ -196,8 +218,8 @@ func TestClearFieldsBeforeReadDuringGeneration(t *testing.T) {
 	}
 	ClearFieldsBeforeRead(nil, "schedule")
 	ClearFieldsBeforeRead(&config.Resource{}, "schedule")
-	ClearStaleBlocksBeforeRead(nil)
-	ClearStaleBlocksBeforeRead(&config.Resource{})
+	UseAuthoritativeRead(nil)
+	UseAuthoritativeRead(&config.Resource{})
 }
 
 func TestClearFieldsBeforeReadClearsSets(t *testing.T) {
@@ -267,7 +289,7 @@ func TestClearFieldsBeforeReadPropagatesDiagnostics(t *testing.T) {
 	}
 }
 
-func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
+func TestUseAuthoritativeReadSelectsFields(t *testing.T) {
 	block := func(s map[string]*schema.Schema) *schema.Schema {
 		return &schema.Schema{
 			Type:     schema.TypeList,
@@ -285,6 +307,8 @@ func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
 		},
 		Schema: map[string]*schema.Schema{
 			"name":     str,
+			"retries":  {Type: schema.TypeInt, Optional: true},
+			"enabled":  {Type: schema.TypeBool, Optional: true},
 			"schedule": block(map[string]*schema.Schema{"cron": str}),
 			"tags": {
 				Type:     schema.TypeMap,
@@ -319,7 +343,7 @@ func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
 		},
 	}}
 
-	ClearStaleBlocksBeforeRead(r, "provider_config")
+	UseAuthoritativeRead(r, "provider_config")
 
 	cleanersMu.Lock()
 	c := cleaners[r.TerraformResource]
@@ -329,7 +353,7 @@ func TestClearStaleBlocksBeforeReadSelectsFields(t *testing.T) {
 	for _, n := range c.names() {
 		got[n] = true
 	}
-	want := []string{"schedule", "tags", "parameters", "ssh_public_keys"}
+	want := []string{"name", "retries", "enabled", "schedule", "tags", "parameters", "ssh_public_keys"}
 	if len(got) != len(want) {
 		t.Fatalf("expected %v, got %v", want, c.names())
 	}

--- a/config/namespaced/job/config.go
+++ b/config/namespaced/job/config.go
@@ -12,8 +12,8 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "compute"
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "format")
 
-		// Clear Stale blocks except for provider_config which carries account provider credentials that the Jobs API never returns.
-		common.ClearStaleBlocksBeforeRead(r, "provider_config")
+		// Preserve schema-only and write-only lifecycle fields across reads.
+		common.UseAuthoritativeRead(r, "provider_config", "always_running", "control_run_state")
 
 		r.References["notebook_task.warehouse_id"] = config.Reference{
 			TerraformName: "databricks_sql_endpoint",


### PR DESCRIPTION
Implemented without modifying the Terraform provider fork.

read.go now:

Automatically clears safe optional fields, including scalars and collections.
Uses MarkNewResource() so Databricks repopulates unconfigured API values.
Removes all sentinel logic.
Supports resource-level opt-in with exceptional exclusions.
Jobs exclude only provider_config, always_running, and control_run_state.

Validation passed:

go test ./config/common/... -count=1
go test ./config/... -count=1
No editor diagnostics or diff errors.